### PR TITLE
allow top cfg to be YAML

### DIFF
--- a/stack.py
+++ b/stack.py
@@ -49,7 +49,7 @@ def _process_stack_cfg(cfg, stack, minion_id, pillar):
         "minion_id": minion_id,
         "pillar": pillar,
         })
-    for path in jenv.get_template(filename).render(stack=stack).splitlines():
+    for path in _parse_top_cfg(jenv.get_template(filename).render(stack=stack)):
         try:
             obj = yaml.safe_load(jenv.get_template(path).render(stack=stack))
             if not isinstance(obj, dict):
@@ -126,3 +126,14 @@ def _merge_list(stack, obj):
         return obj + stack
     else:
         return stack + obj
+
+
+def _parse_top_cfg(content):
+    """Allow top_cfg to be YAML"""
+    try:
+        obj = yaml.safe_load(content)
+        if isinstance(obj, list):
+            return obj
+    except Exception as e:
+        pass
+    return content.splitlines()

--- a/stack.py
+++ b/stack.py
@@ -49,7 +49,7 @@ def _process_stack_cfg(cfg, stack, minion_id, pillar):
         "minion_id": minion_id,
         "pillar": pillar,
         })
-    for path in _parse_top_cfg(jenv.get_template(filename).render(stack=stack)):
+    for path in _parse_stack_cfg(jenv.get_template(filename).render(stack=stack)):
         try:
             obj = yaml.safe_load(jenv.get_template(path).render(stack=stack))
             if not isinstance(obj, dict):
@@ -128,8 +128,8 @@ def _merge_list(stack, obj):
         return stack + obj
 
 
-def _parse_top_cfg(content):
-    """Allow top_cfg to be YAML"""
+def _parse_stack_cfg(content):
+    """Allow top level cfg to be YAML"""
     try:
         obj = yaml.safe_load(content)
         if isinstance(obj, list):


### PR DESCRIPTION
### What does this PR do?

Allows top level pillar.stack configuration to be YAML in a backwards compatible way.
### What issues does this PR fix or reference?

Currently, the top level file is different syntax from the rest of the files supported
by pillar.stack. This is inconsistent and unnecessarily confusing. You can't put
comments on the top cfg in a natural way. Rather you have to use jinja, very carefully:

``` jinja
{# comment here -#}
```

With the `-`, it will produce a blank line, which will be rejected by the current parser.
### Previous Behavior

Only allows a file which exactly matches a "file per line" syntax.
### New Behavior

Try to parse as YAML. If it fails to parse or does not return a `list`, then parse the old way.
### Tests written?

No. There is no base unit test. Could write one, but not sure this PR is going to be accepted so not bothering right now.
