### PR TITLE
log.debug files before parsing

### DIFF
--- a/stack.py
+++ b/stack.py
@@ -40,6 +40,7 @@ def ext_pillar(minion_id, pillar, *args, **kwargs):
 
 
 def _process_stack_cfg(cfg, stack, minion_id, pillar):
+    log.debug('Config: {0}'.format(cfg))
     basedir, filename = os.path.split(cfg)
     jenv = Environment(loader=FileSystemLoader(basedir))
     jenv.globals.update({
@@ -51,6 +52,7 @@ def _process_stack_cfg(cfg, stack, minion_id, pillar):
         })
     for path in jenv.get_template(filename).render(stack=stack).splitlines():
         try:
+            log.debug('YAML: basedir={0}, path={1}'.format(basedir, path))
             obj = yaml.safe_load(jenv.get_template(path).render(stack=stack))
             if not isinstance(obj, dict):
                 log.info('Ignoring pillar stack template "{0}": Can\'t parse '


### PR DESCRIPTION
When an exception occurs during parsing, the output is uninformative, e.g.

``` text
- Failed to load ext_pillar stack: 'dict object' has no attribute 'radia'
```

You don't know which file failed to parse. Added log.debug before parsing so logs look like:

``` text
[DEBUG   ] LazyLoaded stack.ext_pillar
[DEBUG   ] Config: /home/vagrant/src/radiasoft/salt-conf/srv/pillar/top.cfg
[DEBUG   ] YAML: basedir=/home/vagrant/src/radiasoft/salt-conf/srv/pillar, path=channels/dev.yml
[DEBUG   ] YAML: basedir=/home/vagrant/src/radiasoft/salt-conf/srv/pillar, path=radia.yml
[DEBUG   ] YAML: basedir=/home/vagrant/src/radiasoft/salt-conf/srv/pillar, path=jupyterhub/base.yml
[CRITICAL] Pillar render error: Failed to load ext_pillar stack: 'dict object' has no attribute 'radia'
```
