### PR TITLE
Add salt SerializerExtension for yaml filter, etc.

### DIFF
--- a/stack.py
+++ b/stack.py
@@ -41,9 +41,14 @@ def ext_pillar(minion_id, pillar, *args, **kwargs):
     return stack
 
 
+def _construct_unicode(loader, node):
+    return node.value
+
+
 def _process_stack_cfg(cfg, stack, minion_id, pillar):
     log.debug('Config: {0}'.format(cfg))
     basedir, filename = os.path.split(cfg)
+    yaml.SafeLoader.add_constructor("tag:yaml.org,2002:python/unicode", _construct_unicode)
     jenv = Environment(loader=FileSystemLoader(basedir), extensions=['jinja2.ext.do', salt.utils.jinja.SerializerExtension])
     jenv.globals.update({
         "__opts__": __opts__,

--- a/stack.py
+++ b/stack.py
@@ -44,7 +44,7 @@ def ext_pillar(minion_id, pillar, *args, **kwargs):
 def _process_stack_cfg(cfg, stack, minion_id, pillar):
     log.debug('Config: {0}'.format(cfg))
     basedir, filename = os.path.split(cfg)
-    jenv = Environment(loader=FileSystemLoader(basedir), extensions=['jinja2.ext.do'])
+    jenv = Environment(loader=FileSystemLoader(basedir), extensions=['jinja2.ext.do', salt.utils.jinja.SerializerExtension])
     jenv.globals.update({
         "__opts__": __opts__,
         "__salt__": __salt__,


### PR DESCRIPTION
The `SerializerExtension` class in `salt.utils.jinja` lets us (among other things) take an entire dictionary and render it to YAML. For example: `{{ some_dict | yaml }}`.