### PR TITLE
#28 Allow Windows minions to load pillar files in subdirectories

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,6 @@ python:
   - "2.6"
   - "2.7"
 install: pip install salt-ssh docutils Pygments
-script: python test_stack.py
+script: 
+  - python test_stack.py
+  - python test_slashes.py

--- a/test_slashes.py
+++ b/test_slashes.py
@@ -1,0 +1,21 @@
+import os
+import unittest
+
+import stack
+
+
+class TestSlashConvert(unittest.TestCase):
+    def test_relative(self):
+        # start with unix-style
+        source = "test/sub \n dir/file.txt"
+
+        # convert to OS-specific separators; this is a no-op on unix-like systems
+        os_slash = os.path.normpath(source)
+
+        # check that the convert to unix-style gets us back to the start
+        unix_slash = stack._to_unix_slashes(os_slash)
+        self.assertEquals(unix_slash, source)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR allows pillarstack to work on Windows minions when using `salt-call`. Note that the stack configuration files should continue to use Unix-style directory separators.

I'm glad to try a different approach if you think there's a better/cleaner one. Attached is a simplistic/self-contained unit test to validate functionality on Linux and Windows. It's pretty small but if you want it to be part of the project I can add it.

[test_pathconvert.py](https://github.com/bbinet/pillarstack/files/851942/test_pathconvert.txt)

(I've been sharing your 'unit-test via RST' technique with colleages, by the way - great stuff.)