### PR TITLE
Allow indentation in stack configuration files

### DIFF
--- a/stack.py
+++ b/stack.py
@@ -66,7 +66,8 @@ def _process_stack_cfg(cfg, stack, minion_id, pillar):
         })
     for item in _parse_stack_cfg(
             jenv.get_template(filename).render(stack=stack)):
-        if not item.strip():
+        item = item.strip()
+        if not item:
             continue  # silently ignore whitespace or empty lines
         paths = glob.glob(os.path.join(basedir, item))
         if not paths:


### PR DESCRIPTION
Accommodate leading whitespace in stack configuration files. This allows
the Jinja to be formatted in a traditional, nested indentation style.

For example:

```html+jinja
{% for role in pillar.get('roles', []) %}
    role/{{ role }}.yml
    {% if stack.meta[role].foo %}
        extra/thing.yml
    {% endfor %}
{% endfor %}
```


