### PR TITLE
Allow for changing the default merging strategy.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -231,6 +231,14 @@ The merging strategy can be set by including a dict in the form of:
 
     __: <merging strategy>
 
+If you want to use a different default merging strategy, you can do so in your
+salt master config by adding a parameter:
+
+.. code:: yaml
+
+    ext_pillar:
+      - stack: /path/to/stack.cfg?default_strategy=merge-first
+
 as the first item of the dict or list.
 This allows fine grained control over the merging process.
 

--- a/README.rst
+++ b/README.rst
@@ -232,12 +232,12 @@ The merging strategy can be set by including a dict in the form of:
     __: <merging strategy>
 
 If you want to use a different default merging strategy, you can do so in your
-salt master config by adding a parameter:
+salt master config:
 
 .. code:: yaml
 
-    ext_pillar:
-      - stack: /path/to/stack.cfg?default_strategy=merge-first
+    pillarstack:
+        default_strategy: merge-first
 
 as the first item of the dict or list.
 This allows fine grained control over the merging process.

--- a/stack.py
+++ b/stack.py
@@ -36,27 +36,14 @@ def ext_pillar(minion_id, pillar, *args, **kwargs):
         if not isinstance(cfgs, list):
             cfgs = [cfgs]
         stack_config_files += cfgs
-    for cfg in stack_config_files:
-        cfg_path, params = _extract_cfg(cfg)
+    for cfg_path in stack_config_files:
         if not os.path.isfile(cfg_path):
             log.info(
                 'Ignoring pillar stack cfg "%s": file does not exist', cfg_path)
             continue
-        default_strategy = params.get("default_strategy", "merge-last")
+        default_strategy = __opts__.get("pillarstack", {}).get("default_strategy", "merge-last")
         stack = _process_stack_cfg(cfg_path, stack, minion_id, pillar, default_strategy)
     return stack
-
-
-def _extract_cfg(cfg):
-    # Get the path of the config and any parameters.
-    if "?" not in cfg:
-        return cfg, {}
-    path, raw_params = cfg.split("?", 1)
-    params = {}
-    for param in raw_params.split("&"):
-        key, val = param.split("=")
-        params[key] = val
-    return path, params
 
 
 def _to_unix_slashes(path):

--- a/test_stack.py
+++ b/test_stack.py
@@ -39,6 +39,85 @@ class TestStack(unittest.TestCase):
                             'INSTEAD OF =>', after_yml,
                             ]))
 
+    def test_merge_first_explicit_top_level(self):
+        # This checks __ behaviour.
+        cur_stack = {
+            "flat": "First value",
+            "nested": {
+                "val": "First value nested",
+                "nested_again": {
+                    "val": 123
+                }
+            }
+        }
+        obj = {
+            "__": "merge-first",
+            "flat": "Shouldn't overwrite",
+            "flat_newval": "OK",
+            "nested": {
+                "val": "Shouldn't overwrite",
+                "newval": "OK",
+                "nested_again": {
+                    "val": 456,
+                    "newval": 678
+                }
+            }
+        }
+        expected = {
+            "flat": "First value",
+            "flat_newval": "OK",
+            "nested": {
+                "val": "First value nested",
+                "newval": "OK",
+                "nested_again": {
+                    "val": 123,
+                    "newval": 678
+                }
+            }
+        }
+        new_stack = stack._merge_dict(cur_stack, obj)
+        self.assertDictEqual(new_stack, expected)
+
+    def test_merge_first_with_default(self):
+        # This makes sure that we get the same effect as
+        # test_merge_first_explicit_top_level, but using
+        # default_strategy instead.
+        cur_stack = {
+            "flat": "First value",
+            "nested": {
+                "val": "First value nested",
+                "nested_again": {
+                    "val": 123
+                }
+            }
+        }
+        obj = {
+            "flat": "Shouldn't overwrite",
+            "flat_newval": "OK",
+            "nested": {
+                "val": "Shouldn't overwrite",
+                "newval": "OK",
+                "nested_again": {
+                    "val": 456,
+                    "newval": 678
+                }
+            }
+        }
+        expected = {
+            "flat": "First value",
+            "flat_newval": "OK",
+            "nested": {
+                "val": "First value nested",
+                "newval": "OK",
+                "nested_again": {
+                    "val": 123,
+                    "newval": 678
+                }
+            }
+        }
+        new_stack = stack._merge_dict(cur_stack, obj, default_strategy="merge-first")
+        self.assertDictEqual(new_stack, expected)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
We have been using Pillarstack for a week or so now and it's great, it's a real improvement from Salt's built in pillar, but still quite simple. For us, it's made sense to use a merge-first strategy throughout - it gives us layers of increasingly generic defaults.

I found that I was having to put `__: merge-first` in all the files though and I kept forgetting. This is a patch to be able to change the default and take the human error out of the equation.

Configured in the salt master config like this:

    ext_pillar:
      - stack: /path/to/stack.cfg?default_strategy=merge-first

Hopefully this is a useful feature. I feel like the way of configuring it is a bit hackish, but considering how you're already using args, kwargs in ext_pillar, I thought this was the cleanest way of doing it. Or could perhaps switch to a dict style instead of URL parameter style.