### PR TITLE
Throw explicit exception when Yaml format is not correct

### DIFF
--- a/stack.py
+++ b/stack.py
@@ -80,7 +80,14 @@ def _process_stack_cfg(cfg, stack, minion_id, pillar):
             log.debug('YAML: basedir=%s, path=%s', basedir, path)
             # FileSystemLoader always expects unix-style paths
             unix_path = _to_unix_slashes(os.path.relpath(path, basedir))
-            obj = salt.utils.yaml.safe_load(jenv.get_template(unix_path).render(stack=stack, ymlpath=path))
+            try:
+                obj = salt.utils.yaml.safe_load(
+                    jenv.get_template(unix_path).render(stack=stack, ymlpath=path)
+                )
+            except Exception as e:
+                raise Exception(
+                    'Unable to parse {0} file: {1}'.format(unix_path, e)
+                )
             if not isinstance(obj, dict):
                 log.info('Ignoring pillar stack template "%s": Can\'t parse '
                          'as a valid yaml dictionary', path)


### PR DESCRIPTION
This pull request add some details when a yaml file can't be parsed. It helps to locate the concerning file.

Without the fix:
```
local:
    ----------
    _errors:
        - Failed to load ext_pillar stack: mapping values are not allowed in this context
            in "<unicode string>", line 2, column 6
```

With the fix:
```
local:
    ----------
    _errors:
        - Failed to load ext_pillar stack: Unable to parse mypillar.yml file: mapping values are not allowed in this context
            in "<unicode string>", line 2, column 6
```
